### PR TITLE
Refactor testing to test runner pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,6 @@ env:
   - TEST_DIR=posts
 script:
   # run coverage on *test*.py files testing the app module 
-  - cd $TEST_DIR && pip install -r requirements.txt && coverage run --source app *test*.py
+  - cd $TEST_DIR && pip install -r requirements.txt && coverage run --source app test_runner.py
 after_success:
     coveralls

--- a/events/test_events_class.py
+++ b/events/test_events_class.py
@@ -7,32 +7,6 @@ import app
 EXAMPLE_TIME = datetime.datetime(2019, 6, 11, 10, 33, 1, 100000)
 
 
-class TestEventsDB(unittest.TestCase):
-    def setUp(self):
-        self.event_info = {'name': 'test_event',
-                           'description': 'testing!',
-                           'author': 'admin',
-                           'event_time': EXAMPLE_TIME,
-                           'created_at': EXAMPLE_TIME}
-        self.test_event = app.Event(**self.event_info)
-        # Create mock DB for testing
-        self.client = mongomock.MongoClient()
-        self.test_coll = self.client.eventsDB.all_events
-
-    def test_add(self):
-        self.test_event.add_to_db(self.test_coll)
-        queried_event = self.test_coll.find_one(self.event_info)
-        self.assertEqual(app.Event(**queried_event), self.test_event)
-
-    def test_build_info(self):
-        test_info = {'name': 'test_event',
-                     'description': 'testing!',
-                     'author': 'admin',
-                     'event_time': EXAMPLE_TIME, }
-        info = app.build_event_info(test_info, EXAMPLE_TIME)
-        self.assertEqual(info['created_at'], EXAMPLE_TIME)
-
-
 class TestEventsClass(unittest.TestCase):
     def setUp(self):
         self.test_info = {'name': 'test_event',

--- a/events/test_events_db.py
+++ b/events/test_events_db.py
@@ -1,0 +1,37 @@
+import unittest
+import datetime
+import mongomock
+import app
+
+
+EXAMPLE_TIME = datetime.datetime(2019, 6, 11, 10, 33, 1, 100000)
+
+
+class TestEventsDB(unittest.TestCase):
+    def setUp(self):
+        self.event_info = {'name': 'test_event',
+                           'description': 'testing!',
+                           'author': 'admin',
+                           'event_time': EXAMPLE_TIME,
+                           'created_at': EXAMPLE_TIME}
+        self.test_event = app.Event(**self.event_info)
+        # Create mock DB for testing
+        self.client = mongomock.MongoClient()
+        self.test_coll = self.client.eventsDB.all_events
+
+    def test_add(self):
+        self.test_event.add_to_db(self.test_coll)
+        queried_event = self.test_coll.find_one(self.event_info)
+        self.assertEqual(app.Event(**queried_event), self.test_event)
+
+    def test_build_info(self):
+        test_info = {'name': 'test_event',
+                     'description': 'testing!',
+                     'author': 'admin',
+                     'event_time': EXAMPLE_TIME, }
+        info = app.build_event_info(test_info, EXAMPLE_TIME)
+        self.assertEqual(info['created_at'], EXAMPLE_TIME)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/events/test_runner.py
+++ b/events/test_runner.py
@@ -1,0 +1,33 @@
+"""Unit test runner for events service.
+
+Test runner that runs several different test modules.
+To see the tests, look at the sibling test_*.py files."""
+
+# Authors: mukobi
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import sys
+
+
+def run_test_suite():
+    """Generate and run test suite and exit with correct status code."""
+    suite = unittest.TestLoader().discover(".")
+    result = unittest.TextTestRunner().run(suite)
+    sys.exit(not result.wasSuccessful())
+
+
+if __name__ == "__main__":
+    run_test_suite()

--- a/pageserve/test_runner.py
+++ b/pageserve/test_runner.py
@@ -21,20 +21,11 @@ To see the tests, look at the sibling test_*.py files."""
 import unittest
 import sys
 
-import test_serve
-
-
-def generate_suite():
-    """Generates and loads a test suite."""
-    loader = unittest.TestLoader()
-    suite = unittest.TestSuite()
-    suite.addTest(loader.loadTestsFromModule(test_serve))
-    return suite
-
 
 def run_test_suite():
-    """Runs the test suite and exits with correct status code."""
-    result = unittest.TextTestRunner().run(generate_suite())
+    """Generate and run test suite and exit with correct status code."""
+    suite = unittest.TestLoader().discover(".")
+    result = unittest.TextTestRunner().run(suite)
     sys.exit(not result.wasSuccessful())
 
 

--- a/pageserve/test_runner.py
+++ b/pageserve/test_runner.py
@@ -19,6 +19,7 @@ To see the tests, look at the sibling test_*.py files."""
 # limitations under the License.
 
 import unittest
+import sys
 
 import test_serve
 
@@ -31,5 +32,11 @@ def generate_suite():
     return suite
 
 
+def run_test_suite():
+    """Runs the test suite and exits with correct status code."""
+    result = unittest.TextTestRunner().run(generate_suite())
+    sys.exit(not result.wasSuccessful())
+
+
 if __name__ == "__main__":
-    unittest.TextTestRunner().run(generate_suite())
+    run_test_suite()

--- a/pageserve/test_runner.py
+++ b/pageserve/test_runner.py
@@ -1,0 +1,35 @@
+"""Unit test runner for pageserve service.
+
+Test runner that runs several different test modules.
+To see the tests, look at the sibling test_*.py files."""
+
+# Authors: mukobi
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import test_serve
+
+
+def generate_suite():
+    """Generates and loads a test suite."""
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTest(loader.loadTestsFromModule(test_serve))
+    return suite
+
+
+if __name__ == "__main__":
+    unittest.TextTestRunner().run(generate_suite())

--- a/pageserve/test_serve.py
+++ b/pageserve/test_serve.py
@@ -16,11 +16,12 @@ limitations under the License.
 import unittest
 import app
 
+
 class TestServe(unittest.TestCase):
     def test_get_auth(self):
         self.assertTrue(app.get_auth("carolyn"))
         self.assertFalse(app.get_auth("Voldemort"))
-        
-        
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/posts/test_posts.py
+++ b/posts/test_posts.py
@@ -1,0 +1,31 @@
+"""Unit tests for posts service.
+"""
+
+# Authors: mukobi
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import app
+
+
+class TestPosts(unittest.TestCase):
+    """Test /authorization endpoint of users service."""
+
+    def test_basic(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/posts/test_runner.py
+++ b/posts/test_runner.py
@@ -19,6 +19,7 @@ To see the tests, look at the sibling test_*.py files."""
 # limitations under the License.
 
 import unittest
+import sys
 
 import test_posts
 
@@ -31,5 +32,11 @@ def generate_suite():
     return suite
 
 
+def run_test_suite():
+    """Runs the test suite and exits with correct status code."""
+    result = unittest.TextTestRunner().run(generate_suite())
+    sys.exit(not result.wasSuccessful())
+
+
 if __name__ == "__main__":
-    unittest.TextTestRunner().run(generate_suite())
+    run_test_suite()

--- a/posts/test_runner.py
+++ b/posts/test_runner.py
@@ -1,5 +1,7 @@
-"""Unit tests for posts service.
-"""
+"""Unit test runner for users service.
+
+Test runner that runs several different test modules.
+To see the tests, look at the sibling test_*.py files."""
 
 # Authors: mukobi
 # Copyright 2019 The Knative Authors
@@ -17,14 +19,17 @@
 # limitations under the License.
 
 import unittest
-import app
+
+import test_posts
 
 
-class TestPosts(unittest.TestCase):
-    """Test /authorization endpoint of users service."""
-    def test_basic(self):
-        pass
+def generate_suite():
+    """Generates and loads a test suite."""
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTest(loader.loadTestsFromModule(test_posts))
+    return suite
 
 
-if __name__ == '__main__':
-    unittest.main()
+if __name__ == "__main__":
+    unittest.TextTestRunner().run(generate_suite())

--- a/posts/test_runner.py
+++ b/posts/test_runner.py
@@ -21,20 +21,11 @@ To see the tests, look at the sibling test_*.py files."""
 import unittest
 import sys
 
-import test_posts
-
-
-def generate_suite():
-    """Generates and loads a test suite."""
-    loader = unittest.TestLoader()
-    suite = unittest.TestSuite()
-    suite.addTest(loader.loadTestsFromModule(test_posts))
-    return suite
-
 
 def run_test_suite():
-    """Runs the test suite and exits with correct status code."""
-    result = unittest.TextTestRunner().run(generate_suite())
+    """Generate and run test suite and exit with correct status code."""
+    suite = unittest.TestLoader().discover(".")
+    result = unittest.TextTestRunner().run(suite)
     sys.exit(not result.wasSuccessful())
 
 

--- a/posts/test_runner.py
+++ b/posts/test_runner.py
@@ -1,4 +1,4 @@
-"""Unit test runner for users service.
+"""Unit test runner for posts service.
 
 Test runner that runs several different test modules.
 To see the tests, look at the sibling test_*.py files."""

--- a/users/test_authorization.py
+++ b/users/test_authorization.py
@@ -1,0 +1,67 @@
+"""Unit tests for users service authorization functions."""
+
+# Authors: mukobi
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import mongomock
+import app
+
+AUTHORIZED_USER = "authorized-user"
+NON_AUTHORIZED_USER = "non-authorized-user"
+MALFORMATTED_IN_DB_USER = "this-user-has-no-'is_organizer'_db_field"
+MISSING_USER = "not-a-user-in-the-database"
+
+
+class TestAuthorization(unittest.TestCase):
+    """Test /authorization endpoint of users service."""
+
+    def setUp(self):
+        """Seed mock DB for testing"""
+        self.mock_collection = mongomock.MongoClient().db.collection
+        mock_data = [
+            {"user_id": AUTHORIZED_USER,
+             "name": AUTHORIZED_USER,
+             "is_organizer": True},
+            {"user_id": NON_AUTHORIZED_USER,
+             "name": NON_AUTHORIZED_USER,
+             "is_organizer": False},
+            {"user_id": MALFORMATTED_IN_DB_USER}
+        ]
+        self.mock_collection.insert_many(mock_data)
+
+    def test_authorized_user_is_authorized(self):
+        """An authorized user should receive authorized privileges."""
+        self.assertTrue(app.find_authorization_in_db(
+            AUTHORIZED_USER, self.mock_collection))
+
+    def test_non_authorized_user_not_authorized(self):
+        """A non-authorized user should not receive authorized privileges."""
+        self.assertFalse(app.find_authorization_in_db(
+            NON_AUTHORIZED_USER, self.mock_collection))
+
+    def test_malformatted_user_none_authorization(self):
+        """An incorrect db schema should not receive authorized privileges."""
+        self.assertFalse(app.find_authorization_in_db(
+            MISSING_USER, self.mock_collection))
+
+    def test_unkown_user_not_authorized(self):
+        """A user not in the db should not receive authorized privileges."""
+        self.assertFalse(app.find_authorization_in_db(
+            MALFORMATTED_IN_DB_USER, self.mock_collection))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/users/test_runner.py
+++ b/users/test_runner.py
@@ -19,6 +19,7 @@ To see the tests, look at the sibling test_*.py files."""
 # limitations under the License.
 
 import unittest
+import sys
 
 import test_authorization
 import test_user_upsertion
@@ -33,5 +34,11 @@ def generate_suite():
     return suite
 
 
+def run_test_suite():
+    """Runs the test suite and exits with correct status code."""
+    result = unittest.TextTestRunner().run(generate_suite())
+    sys.exit(not result.wasSuccessful())
+
+
 if __name__ == "__main__":
-    unittest.TextTestRunner().run(generate_suite())
+    run_test_suite()

--- a/users/test_runner.py
+++ b/users/test_runner.py
@@ -1,0 +1,33 @@
+"""Unit test runner for users service.
+
+Test runner that runs several different test modules.
+To see the tests, look at the sibling test_*.py files."""
+
+# Authors: mukobi
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import test_authorization
+import test_user_upsertion
+
+
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTest(loader.loadTestsFromModule(test_authorization))
+    suite.addTest(loader.loadTestsFromModule(test_user_upsertion))
+
+    unittest.TextTestRunner().run(suite)

--- a/users/test_runner.py
+++ b/users/test_runner.py
@@ -21,22 +21,11 @@ To see the tests, look at the sibling test_*.py files."""
 import unittest
 import sys
 
-import test_authorization
-import test_user_upsertion
-
-
-def generate_suite():
-    """Generates and loads a test suite."""
-    loader = unittest.TestLoader()
-    suite = unittest.TestSuite()
-    suite.addTest(loader.loadTestsFromModule(test_authorization))
-    suite.addTest(loader.loadTestsFromModule(test_user_upsertion))
-    return suite
-
 
 def run_test_suite():
-    """Runs the test suite and exits with correct status code."""
-    result = unittest.TextTestRunner().run(generate_suite())
+    """Generate and run test suite and exit with correct status code."""
+    suite = unittest.TestLoader().discover(".")
+    result = unittest.TextTestRunner().run(suite)
     sys.exit(not result.wasSuccessful())
 
 

--- a/users/test_runner.py
+++ b/users/test_runner.py
@@ -24,10 +24,14 @@ import test_authorization
 import test_user_upsertion
 
 
-if __name__ == "__main__":
+def generate_suite():
+    """Generates and loads a test suite."""
     loader = unittest.TestLoader()
     suite = unittest.TestSuite()
     suite.addTest(loader.loadTestsFromModule(test_authorization))
     suite.addTest(loader.loadTestsFromModule(test_user_upsertion))
+    return suite
 
-    unittest.TextTestRunner().run(suite)
+
+if __name__ == "__main__":
+    unittest.TextTestRunner().run(generate_suite())

--- a/users/test_user_upsertion.py
+++ b/users/test_user_upsertion.py
@@ -101,7 +101,7 @@ class TestUserUpsertion(unittest.TestCase):
         }
         upserted_id = None
         # upsert many times
-        for i in range(42):
+        for _ in range(42):
             upserted_id = app.upsert_user_in_db(
                 user_to_insert, self.mock_collection)
         # only 1 user has been inserted

--- a/users/test_user_upsertion.py
+++ b/users/test_user_upsertion.py
@@ -1,4 +1,4 @@
-"""Unit tests for users service."""
+"""Unit tests for users service user upsertion functions."""
 
 # Authors: mukobi
 # Copyright 2019 The Knative Authors
@@ -19,52 +19,9 @@ import unittest
 import mongomock
 import app
 
-AUTHORIZED_USER = "authorized-user"
-NON_AUTHORIZED_USER = "non-authorized-user"
-MALFORMATTED_IN_DB_USER = "this-user-has-no-'is_organizer'_db_field"
-MISSING_USER = "not-a-user-in-the-database"
-
 USER_ID = "valid-user-id"
 USER_NAME = "Valid User Name"
 ADDITIONAL_INFORMATION = "I'm not found in other documents"
-
-
-class TestAuthorization(unittest.TestCase):
-    """Test /authorization endpoint of users service."""
-
-    def setUp(self):
-        """Seed mock DB for testing"""
-        self.mock_collection = mongomock.MongoClient().db.collection
-        mock_data = [
-            {"user_id": AUTHORIZED_USER,
-             "name": AUTHORIZED_USER,
-             "is_organizer": True},
-            {"user_id": NON_AUTHORIZED_USER,
-             "name": NON_AUTHORIZED_USER,
-             "is_organizer": False},
-            {"user_id": MALFORMATTED_IN_DB_USER}
-        ]
-        self.mock_collection.insert_many(mock_data)
-
-    def test_authorized_user_is_authorized(self):
-        """An authorized user should receive authorized privileges."""
-        self.assertTrue(app.find_authorization_in_db(
-            AUTHORIZED_USER, self.mock_collection))
-
-    def test_non_authorized_user_not_authorized(self):
-        """A non-authorized user should not receive authorized privileges."""
-        self.assertFalse(app.find_authorization_in_db(
-            NON_AUTHORIZED_USER, self.mock_collection))
-
-    def test_malformatted_user_none_authorization(self):
-        """An incorrect db schema should not receive authorized privileges."""
-        self.assertFalse(app.find_authorization_in_db(
-            MISSING_USER, self.mock_collection))
-
-    def test_unkown_user_not_authorized(self):
-        """A user not in the db should not receive authorized privileges."""
-        self.assertFalse(app.find_authorization_in_db(
-            MALFORMATTED_IN_DB_USER, self.mock_collection))
 
 
 class TestUserUpsertion(unittest.TestCase):


### PR DESCRIPTION
Change automated test setup (including Travis-CI) to use a test runner pattern. Travis runs coverage on one `test_runner.py` file in each directory which handles importing sibling unit test modules, loading them into a test runner, and running all of them. 

This allows for a cleaner codebase, shorter individual test files, the isolation of tests relevant to a particular module or function of an app into different files, and the ability to easily test only certain parts of an app by running those seperate files.

To demonstrate this, I also went along and split up the horribly long `/users/test.py` file which previously had 2 test case classes into 2 separate files, one for each class.