### PR TITLE
Fix mislabeled users tests

### DIFF
--- a/posts/test_runner.py
+++ b/posts/test_runner.py
@@ -1,0 +1,33 @@
+"""Unit test runner for posts service.
+
+Test runner that runs several different test modules.
+To see the tests, look at the sibling test_*.py files."""
+
+# Authors: mukobi
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import sys
+
+
+def run_test_suite():
+    """Generate and run test suite and exit with correct status code."""
+    suite = unittest.TestLoader().discover(".")
+    result = unittest.TextTestRunner().run(suite)
+    sys.exit(not result.wasSuccessful())
+
+
+if __name__ == "__main__":
+    run_test_suite()

--- a/users/test_authorization.py
+++ b/users/test_authorization.py
@@ -55,12 +55,12 @@ class TestAuthorization(unittest.TestCase):
     def test_malformatted_user_none_authorization(self):
         """An incorrect db schema should not receive authorized privileges."""
         self.assertFalse(app.find_authorization_in_db(
-            MISSING_USER, self.mock_collection))
+            MALFORMATTED_IN_DB_USER, self.mock_collection))
 
     def test_unkown_user_not_authorized(self):
         """A user not in the db should not receive authorized privileges."""
         self.assertFalse(app.find_authorization_in_db(
-            MALFORMATTED_IN_DB_USER, self.mock_collection))
+            MISSING_USER, self.mock_collection))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix a small switch up in the names/docstrings of two tests with their code bodies.