### PR TITLE
Fix JSON serialization error

### DIFF
--- a/events/app.py
+++ b/events/app.py
@@ -79,6 +79,7 @@ def get_all_events():
     """Return a list of all events currently in the DB."""
     try:
         events = EVENTS_COLL.find()
+        events = [Event(**ev).dict for ev in events]
         events_dict = build_events_dict(events)
         # TODO(cmei4444): test with pageserve to make sure the json format is
         # correct in the response

--- a/events/app.py
+++ b/events/app.py
@@ -1,6 +1,8 @@
 import os
 import datetime
+import json
 import pymongo
+from bson import json_util
 
 from flask import Flask, request, Response, jsonify
 from eventclass import Event
@@ -80,7 +82,9 @@ def get_all_events():
         events_dict = build_events_dict(events)
         # TODO(cmei4444): test with pageserve to make sure the json format is
         # correct in the response
-        return jsonify(events_dict)
+        # handle objects from MongoDB (e.g. ObjectID) that aren't JSON
+        # serializable
+        return json.loads(json_util.dumps(events_dict))
     except DBNotConnectedError as e:
         return "Events database was undefined.", 500
 

--- a/events/app.py
+++ b/events/app.py
@@ -4,7 +4,7 @@ import json
 import pymongo
 from bson import json_util
 
-from flask import Flask, request, Response, jsonify
+from flask import Flask, request, Response
 from eventclass import Event
 
 app = Flask(__name__)


### PR DESCRIPTION
Changed the way of converting the retrieved events into the returned JSON (since things like ObjectID in MongoDB aren't JSON serializable)