### PR TITLE
(XS) Change DBNotConnectedError to inherit from ConnectionError

### DIFF
--- a/events/app.py
+++ b/events/app.py
@@ -10,7 +10,7 @@ from eventclass import Event
 app = Flask(__name__)
 
 
-class DBNotConnectedError(EnvironmentError):
+class DBNotConnectedError(ConnectionError):
     """Raised when not able to connect to the db."""
 
 

--- a/users/app.py
+++ b/users/app.py
@@ -117,7 +117,7 @@ def find_authorization_in_db(username, users_collection):
 def connect_to_mongodb():  # pragma: no cover
     """Connect to MongoDB instance using env vars."""
 
-    class DBNotConnectedError(EnvironmentError):
+    class DBNotConnectedError(ConnectionError):
         """Raised when not able to connect to the db."""
 
     class Thrower():  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
`EnvironmentError`, which we had been inheriting from for our custom errors on failing to connect to the DB, is deprecated. It works for compatibility reasons, but Python 3.3 merged it (along with a couple others) into aliases for `OSError` (not sure why pylint didn't warn me about this until now). Anyway, I changed it to inherit from the not-yet-deprecated `ConnectionError` instead.