### PR TITLE
(M) User authenticate preserve is_organizer in db

### DIFF
--- a/users/app.py
+++ b/users/app.py
@@ -63,8 +63,7 @@ def authenticate_and_get_user():
         idinfo = get_user_from_gauth_token(gauth_token)
         user_object = {
             "user_id": idinfo["sub"],
-            "name": idinfo["name"],
-            "is_organizer": False}  # authorization defaults false
+            "name": idinfo["name"]}
         upsert_user_in_db(user_object, app.config["COLLECTION"])
         response = make_response(jsonify(user_object), 201)
         response.headers['Access-Control-Allow-Origin'] = '*'
@@ -105,8 +104,8 @@ def upsert_user_in_db(user_object, users_collection):
     """Updates or inserts the user object into users_collection.
 
     Args:
-        user_object (dict): must contain a user_id, name, and is_organizer,
-            and must not contain other attributes.
+        user_object (dict): must contain a user_id and name and must not
+            contain other attributes.
         users_collection (pymongo.collection): the MongoDB collection to use.
 
     Returns:
@@ -116,13 +115,14 @@ def upsert_user_in_db(user_object, users_collection):
     Raises:
         AttributeError: if user_object is malformatted.
     """
-    required_attributes = {"user_id", "name", "is_organizer"}
+    required_attributes = {"user_id", "name"}
     if user_object.keys() != required_attributes:
         raise AttributeError("malformatted user object")
     # upsert user in db
     return users_collection.update_one(
         {"user_id": user_object["user_id"]},
-        {"$set": user_object},
+        {"$set": user_object,
+         "$setOnInsert": {"is_organizer": False}},
         upsert=True).upserted_id
 
 

--- a/users/test_user_upsertion.py
+++ b/users/test_user_upsertion.py
@@ -49,6 +49,8 @@ class TestUserUpsertion(unittest.TestCase):
         # original user attributes matches found user attributes
         self.assertEqual(user_to_insert["user_id"], found_user["user_id"])
         self.assertEqual(user_to_insert["name"], found_user["name"])
+        # authorization false by default
+        self.assertFalse(found_user["is_organizer"])
         # user returned from app.upsert_user_in_db matches found user exactly
         returned_user = self.mock_collection.find_one(upserted_id)
         self.assertEqual(returned_user, found_user)
@@ -129,6 +131,8 @@ class TestUserUpsertion(unittest.TestCase):
         # original user attributes matches found user attributes
         self.assertEqual(user_to_insert["user_id"], found_user["user_id"])
         self.assertEqual(user_to_insert["name"], found_user["name"])
+        # authorization false by default
+        self.assertFalse(found_user["is_organizer"])
         # user returned from app.upsert_user_in_db matches found user exactly
         returned_user = self.mock_collection.find_one(upserted_id)
         self.assertEqual(returned_user, found_user)

--- a/users/test_user_upsertion.py
+++ b/users/test_user_upsertion.py
@@ -53,6 +53,34 @@ class TestUserUpsertion(unittest.TestCase):
         returned_user = self.mock_collection.find_one(upserted_id)
         self.assertEqual(returned_user, found_user)
 
+    def test_update_existing_user(self):
+        """A valid user object should be upserted and retrieved correctly.
+
+        Checks the user found after upsertion both against the original
+        object added to the database and against the object found with
+        the ObjectID returned from app.upsert_user_in_db.
+        """
+        user_to_insert = {
+            "user_id": USER_ID,
+            "name": USER_NAME
+        }
+        # add a user
+        self.assertIsNotNone(app.upsert_user_in_db(
+            user_to_insert, self.mock_collection))
+        # give that user organizer authorization
+        self.mock_collection.update(
+            {"user_id": USER_ID}, {"$set": {"is_organizer": True}})
+        # update the user
+        user_to_insert["name"] += "...look I changed my name!"
+        self.assertIsNone(app.upsert_user_in_db(
+            user_to_insert, self.mock_collection))  # None on update
+        found_user = self.mock_collection.find_one({"user_id": USER_ID})
+        # original user attributes matches found user attributes
+        self.assertEqual(user_to_insert["user_id"], found_user["user_id"])
+        self.assertEqual(user_to_insert["name"], found_user["name"])
+        # update didn't override authorization field
+        self.assertTrue(found_user["is_organizer"])
+
     def test_malformatted_user_not_inserted(self):
         """A malformatted user_object should not be inserted.
 

--- a/users/test_user_upsertion.py
+++ b/users/test_user_upsertion.py
@@ -40,8 +40,7 @@ class TestUserUpsertion(unittest.TestCase):
         """
         user_to_insert = {
             "user_id": USER_ID,
-            "name": USER_NAME,
-            "is_organizer": False
+            "name": USER_NAME
         }
         upserted_id = app.upsert_user_in_db(
             user_to_insert, self.mock_collection)
@@ -50,8 +49,6 @@ class TestUserUpsertion(unittest.TestCase):
         # original user attributes matches found user attributes
         self.assertEqual(user_to_insert["user_id"], found_user["user_id"])
         self.assertEqual(user_to_insert["name"], found_user["name"])
-        self.assertEqual(
-            user_to_insert["is_organizer"], found_user["is_organizer"])
         # user returned from app.upsert_user_in_db matches found user exactly
         returned_user = self.mock_collection.find_one(upserted_id)
         self.assertEqual(returned_user, found_user)
@@ -68,25 +65,20 @@ class TestUserUpsertion(unittest.TestCase):
         # missing name
         with self.assertRaises(AttributeError):
             app.upsert_user_in_db(
-                {"user_id": USER_ID, "is_organizer": False},
+                {"user_id": USER_ID},
                 self.mock_collection)
         # missing user_id
         with self.assertRaises(AttributeError):
             app.upsert_user_in_db(
-                {"name": USER_NAME, "is_organizer": False},
+                {"name": USER_NAME},
                 self.mock_collection)
-        # missing is_organizer
-        with self.assertRaises(AttributeError):
-            app.upsert_user_in_db(
-                {"user_id": USER_ID, "name": USER_NAME},
-                self.mock_collection)
-        # missing all
+        # missing both
         with self.assertRaises(AttributeError):
             app.upsert_user_in_db({}, self.mock_collection)
         # too much info
         with self.assertRaises(AttributeError):
             app.upsert_user_in_db(
-                {"user_id": USER_ID, "name": USER_NAME, "is_organizer": False,
+                {"user_id": USER_ID, "name": USER_NAME,
                  "additional_info": ADDITIONAL_INFORMATION},
                 self.mock_collection)
         # no users should have been inserted
@@ -96,8 +88,7 @@ class TestUserUpsertion(unittest.TestCase):
         """Upserting the same user multiple times should insert once."""
         user_to_insert = {
             "user_id": USER_ID,
-            "name": USER_NAME,
-            "is_organizer": False
+            "name": USER_NAME
         }
         upserted_id = None
         # upsert many times
@@ -110,8 +101,6 @@ class TestUserUpsertion(unittest.TestCase):
         # original user attributes matches found user attributes
         self.assertEqual(user_to_insert["user_id"], found_user["user_id"])
         self.assertEqual(user_to_insert["name"], found_user["name"])
-        self.assertEqual(
-            user_to_insert["is_organizer"], found_user["is_organizer"])
         # user returned from app.upsert_user_in_db matches found user exactly
         returned_user = self.mock_collection.find_one(upserted_id)
         self.assertEqual(returned_user, found_user)


### PR DESCRIPTION
Previously (in #31), the authentication endpoint would replace the value of the `is_organizer` field with a default of False in the database whenever a user signed in. This uses the special `$setOnInsert` Mongo command to only set this value on a new user creation. Otherwise, it preserves the existing value of `is_organizer` in the database for the user. This allows us to use the /v1/authenticate endpoint as a secure way not only to create new users when logging in with OAuth but also to query the exact `user_id`, `name`, or `is_organizer` fields of a user from another service using their Google Auth ID token without worrying about overriding their authorization level in the database.

This effectively makes the /v1/authorization endpoint (for getting the authentication of a user based on their `user_id`) almost useless, as /v1/authentication should be preferred since it's simpler, based on secure authorization tokens, and only lets the user see the authorization of themselves. The only case for keeping the /v1/authorization endpoint might be if we wanted to also show a list of all the event organizers somewhere, though that might do better in a separate endpoint that simply queries the db for all organizers.