### PR TITLE
Reorder events app.py functions

### DIFF
--- a/events/app.py
+++ b/events/app.py
@@ -11,30 +11,23 @@ from eventclass import Event
 app = Flask(__name__)
 
 
-class DBNotConnectedError(ConnectionError):
-    """Raised when not able to connect to the db."""
+@app.route('/v1/', methods=['GET'])
+def get_all_events():
+    """Return a list of all events currently in the DB."""
+    try:
+        events = app.config["COLLECTION"].find({})
+        events = [Event(**ev).dict for ev in events]
+        events_dict = build_events_dict(events)
+        # handle MongoDB objects (e.g. ObjectID) that aren't JSON serializable
+        return json.loads(json_util.dumps(events_dict))
+    except DBNotConnectedError as e:
+        return "Events database was undefined.", 500
 
 
-def connect_to_mongodb():   # pragma: no cover
-    # TODO(cmei4444): restructure to be consistent with other services
-    """Connects to MongoDB Atlas database.
-
-    Returns events collection if connection is successful, and None otherwise.
-    """
-    class Thrower():  # pylint: disable=too-few-public-methods
-        """Used to raise an exception on failed db connect."""
-
-        def __getattribute__(self, _):
-            raise DBNotConnectedError(
-                "Not able to find MONGODB_URI environment variable")
-
-    mongodb_uri = os.environ.get("MONGODB_URI")
-    if mongodb_uri is None:
-        return Thrower()  # not able to find db config var
-    return pymongo.MongoClient(mongodb_uri).eventsDB.all_events
-
-
-app.config["COLLECTION"] = connect_to_mongodb()  # None if can't connect
+@app.route('/v1/search', methods=['GET'])
+def search_event():
+    """Search for the event with the given name in the DB."""
+    pass
 
 
 @app.route('/v1/add', methods=['POST'])
@@ -60,28 +53,21 @@ def add_event():
         return "Events database was undefined.", 500
 
 
-def build_event_info(info, time):
-    """Adds created_at time to event info dict."""
-    return {**info, 'created_at': time}
-
-
 @app.route('/v1/edit/<event_id>', methods=['PUT'])
 def edit_event(event_id):
     """Edit the event with the given id."""
     pass
 
 
-@app.route('/v1/', methods=['GET'])
-def get_all_events():
-    """Return a list of all events currently in the DB."""
-    try:
-        events = app.config["COLLECTION"].find({})
-        events = [Event(**ev).dict for ev in events]
-        events_dict = build_events_dict(events)
-        # handle MongoDB objects (e.g. ObjectID) that aren't JSON serializable
-        return json.loads(json_util.dumps(events_dict))
-    except DBNotConnectedError as e:
-        return "Events database was undefined.", 500
+@app.route('/v1/<event_id>', methods=['PUT'])
+def get_one_event(event_id):
+    """Retrieve one event by event_id."""
+    pass
+
+
+def build_event_info(info, time):
+    """Adds created_at time to event info dict."""
+    return {**info, 'created_at': time}
 
 
 def build_events_dict(events):
@@ -94,16 +80,30 @@ def build_events_dict(events):
     return {'events': events_list, 'num_events': num_events}
 
 
-@app.route('/v1/search', methods=['GET'])
-def search_event():
-    """Search for the event with the given name in the DB."""
-    pass
+class DBNotConnectedError(ConnectionError):
+    """Raised when not able to connect to the db."""
 
 
-@app.route('/v1/<event_id>', methods=['PUT'])
-def get_one_event(event_id):
-    """Retrieve one event by event_id."""
-    pass
+def connect_to_mongodb():   # pragma: no cover
+    # TODO(cmei4444): restructure to be consistent with other services
+    """Connects to MongoDB Atlas database.
+
+    Returns events collection if connection is successful, and None otherwise.
+    """
+    class Thrower():  # pylint: disable=too-few-public-methods
+        """Used to raise an exception on failed db connect."""
+
+        def __getattribute__(self, _):
+            raise DBNotConnectedError(
+                "Not able to find MONGODB_URI environment variable")
+
+    mongodb_uri = os.environ.get("MONGODB_URI")
+    if mongodb_uri is None:
+        return Thrower()  # not able to find db config var
+    return pymongo.MongoClient(mongodb_uri).eventsDB.all_events
+
+
+app.config["COLLECTION"] = connect_to_mongodb()  # None if can't connect
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
This is really more to discuss file ordering - I used this order here, imitating the pageserve app.py order:

GET endpoints
POST endpoints
PUT endpoints
helper functions
config functions
__main__

Within those categories I don't feel super strongly about a way to order them as long as it seems logical, would like input for this file and other app.py files as well. 