### PR TITLE
Events creation time timestamp as string

### DIFF
--- a/events/app.py
+++ b/events/app.py
@@ -42,7 +42,8 @@ def add_event():
         }
         # TODO(cmei4444): Athenticate user and verify that user has event
         # editing access
-        current_time = datetime.datetime.utcnow().isoformat(" ", "seconds")
+        current_time = datetime.datetime.utcnow().isoformat(sep=" ",
+                                                            timespec="seconds")
         info = build_event_info(info, current_time)
         event = Event(**info)
         app.config["COLLECTION"].insert_one(event.dict)

--- a/events/app.py
+++ b/events/app.py
@@ -42,7 +42,7 @@ def add_event():
         }
         # TODO(cmei4444): Athenticate user and verify that user has event
         # editing access
-        current_time = datetime.datetime.now()
+        current_time = datetime.datetime.utcnow().isoformat(" ", "seconds")
         info = build_event_info(info, current_time)
         event = Event(**info)
         app.config["COLLECTION"].insert_one(event.dict)

--- a/events/eventclass.py
+++ b/events/eventclass.py
@@ -20,13 +20,13 @@ def equal_times(time_1, time_2):
     Strings representing times are directly compared for equality.
     """
     if type(time_1) is type(time_2):
-        if isinstance(time_1, datetime.datetime):
-            time_1 = time_1.replace(
-                microsecond=(time_1.microsecond // 1000) * 1000)
-            time_2 = time_2.replace(
-                microsecond=(time_2.microsecond // 1000) * 1000)
+        # if isinstance(time_1, datetime.datetime):
+        #     time_1 = time_1.replace(
+        #         microsecond=(time_1.microsecond // 1000) * 1000)
+        #     time_2 = time_2.replace(
+        #         microsecond=(time_2.microsecond // 1000) * 1000)
         return time_1 == time_2
-    return False
+    # return False
 
 
 class Event(namedtuple("EventTuple", EVENT_ATTRIBUTES)):

--- a/events/eventclass.py
+++ b/events/eventclass.py
@@ -1,4 +1,3 @@
-import datetime
 from collections import namedtuple
 
 EVENT_ATTRIBUTES = [
@@ -8,19 +7,6 @@ EVENT_ATTRIBUTES = [
     'author',
     'created_at',
     'event_time']
-
-
-def equal_times(time_1, time_2):
-    """Determines if two times are equal.
-
-    Datetime objects are rounded to the nearest millisecond before comparison.
-    Used for comparing Event objects, since MongoDB truncates times to the
-    nearest millisecond.
-
-    Strings representing times are directly compared for equality.
-    """
-    if type(time_1) is type(time_2):
-        return time_1 == time_2
 
 
 class Event(namedtuple("EventTuple", EVENT_ATTRIBUTES)):
@@ -53,9 +39,6 @@ class Event(namedtuple("EventTuple", EVENT_ATTRIBUTES)):
         for att in EVENT_ATTRIBUTES:
             if att == 'event_id':
                 continue
-            if att in ('event_time', 'created_at'):
-                if not equal_times(getattr(self, att), getattr(other, att)):
-                    return False
             elif getattr(self, att) != getattr(other, att):
                 return False
         return True

--- a/events/eventclass.py
+++ b/events/eventclass.py
@@ -20,13 +20,7 @@ def equal_times(time_1, time_2):
     Strings representing times are directly compared for equality.
     """
     if type(time_1) is type(time_2):
-        # if isinstance(time_1, datetime.datetime):
-        #     time_1 = time_1.replace(
-        #         microsecond=(time_1.microsecond // 1000) * 1000)
-        #     time_2 = time_2.replace(
-        #         microsecond=(time_2.microsecond // 1000) * 1000)
         return time_1 == time_2
-    # return False
 
 
 class Event(namedtuple("EventTuple", EVENT_ATTRIBUTES)):

--- a/events/eventclass.py
+++ b/events/eventclass.py
@@ -1,3 +1,4 @@
+import datetime
 from collections import namedtuple
 
 EVENT_ATTRIBUTES = [
@@ -15,10 +16,17 @@ def equal_times(time_1, time_2):
     Datetime objects are rounded to the nearest millisecond before comparison.
     Used for comparing Event objects, since MongoDB truncates times to the
     nearest millisecond.
+
+    Strings representing times are directly compared for equality.
     """
-    time_1 = time_1.replace(microsecond=(time_1.microsecond // 1000) * 1000)
-    time_2 = time_2.replace(microsecond=(time_2.microsecond // 1000) * 1000)
-    return time_1 == time_2
+    if type(time_1) is type(time_2):
+        if isinstance(time_1, datetime.datetime):
+            time_1 = time_1.replace(
+                microsecond=(time_1.microsecond // 1000) * 1000)
+            time_2 = time_2.replace(
+                microsecond=(time_2.microsecond // 1000) * 1000)
+        return time_1 == time_2
+    return False
 
 
 class Event(namedtuple("EventTuple", EVENT_ATTRIBUTES)):

--- a/events/test_events_class.py
+++ b/events/test_events_class.py
@@ -3,17 +3,16 @@ import datetime
 import app
 
 
-EXAMPLE_TIME = datetime.datetime(2019, 6, 11, 10, 33, 1, 100000)
-EXAMPLE_TIME_STRING = EXAMPLE_TIME.isoformat(" ", "seconds")
-
+EXAMPLE_TIME_STRING = datetime.datetime(
+    2019, 6, 11, 10, 33, 1, 100000).isoformat(sep=" ", timespec="seconds")
 
 class TestEventsClass(unittest.TestCase):
     def setUp(self):
         self.test_info = {'name': 'test_event',
                           'description': 'testing!',
                           'author': 'admin',
-                          'event_time': EXAMPLE_TIME,
-                          'created_at': EXAMPLE_TIME}
+                          'event_time': EXAMPLE_TIME_STRING,
+                          'created_at': EXAMPLE_TIME_STRING}
         self.test_info_with_id = dict(event_id=1, **self.test_info)
         self.test_info_with_db_id = dict(event_id=1, _id=2, **self.test_info)
 
@@ -56,36 +55,15 @@ class TestEventsClass(unittest.TestCase):
         event_diff = app.Event(**test_info_diff)
         self.assertNotEqual(event, event_diff)
 
-    def test_events_equal_time_rounding(self):
-        test_info_time = self.test_info.copy()
-        test_info_time['created_at'] = datetime.datetime(
-            2017, 8, 28, 10, 33, 1, 100000)
-        test_info_unrounded = self.test_info.copy()
-        test_info_unrounded['created_at'] = datetime.datetime(
-            2017, 8, 28, 10, 33, 1, 100435)
-
-        event_rounded = app.Event(**test_info_time)
-        event_unrounded = app.Event(**test_info_unrounded)
-        self.assertEqual(event_rounded, event_unrounded)
-
-    def test_events_unequal_time(self):
-        test_info_time = self.test_info.copy()
-        test_info_time['created_at'] = datetime.datetime(
-            2017, 8, 28, 10, 33, 1, 100000)
-        test_info_diff = self.test_info.copy()
-        test_info_diff['created_at'] = datetime.datetime(
-            2017, 8, 28, 10, 33, 1, 0)
-
-        event = app.Event(**test_info_time)
-        event_diff = app.Event(**test_info_diff)
-        self.assertNotEqual(event, event_diff)
-
-    def test_events_time_string(self):
+    def test_events_equal_times(self):
         test_info_str_time = self.test_info.copy()
         test_info_str_time['created_at'] = EXAMPLE_TIME_STRING
         self.test_info['created_at'] = EXAMPLE_TIME_STRING
         self.assertEqual(self.test_info, test_info_str_time)
 
+    def test_events_unequal_times(self):
+        test_info_str_time = self.test_info.copy()
+        test_info_str_time['created_at'] = EXAMPLE_TIME_STRING
         self.test_info['created_at'] = EXAMPLE_TIME_STRING + " different str"
         self.assertNotEqual(self.test_info, test_info_str_time)
 

--- a/events/test_events_class.py
+++ b/events/test_events_class.py
@@ -4,6 +4,7 @@ import app
 
 
 EXAMPLE_TIME = datetime.datetime(2019, 6, 11, 10, 33, 1, 100000)
+EXAMPLE_TIME_STRING = EXAMPLE_TIME.isoformat(" ", "seconds")
 
 
 class TestEventsClass(unittest.TestCase):
@@ -78,6 +79,15 @@ class TestEventsClass(unittest.TestCase):
         event = app.Event(**test_info_time)
         event_diff = app.Event(**test_info_diff)
         self.assertNotEqual(event, event_diff)
+
+    def test_events_time_string(self):
+        test_info_str_time = self.test_info.copy()
+        test_info_str_time['created_at'] = EXAMPLE_TIME_STRING
+        self.test_info['created_at'] = EXAMPLE_TIME_STRING
+        self.assertEqual(self.test_info, test_info_str_time)
+
+        self.test_info['created_at'] = EXAMPLE_TIME_STRING + " different str"
+        self.assertNotEqual(self.test_info, test_info_str_time)
 
 
 if __name__ == '__main__':

--- a/events/test_events_class.py
+++ b/events/test_events_class.py
@@ -6,6 +6,7 @@ import app
 EXAMPLE_TIME_STRING = datetime.datetime(
     2019, 6, 11, 10, 33, 1, 100000).isoformat(sep=" ", timespec="seconds")
 
+
 class TestEventsClass(unittest.TestCase):
     def setUp(self):
         self.test_info = {'name': 'test_event',

--- a/events/test_events_db.py
+++ b/events/test_events_db.py
@@ -3,7 +3,8 @@ import datetime
 import mongomock
 import app
 
-EXAMPLE_TIME = datetime.datetime(2019, 6, 11, 10, 33, 1, 100000)
+EXAMPLE_TIME_STRING = datetime.datetime(
+    2019, 6, 11, 10, 33, 1, 100000).isoformat(sep=" ", timespec="seconds")
 
 
 class TestEventsDB(unittest.TestCase):
@@ -11,8 +12,8 @@ class TestEventsDB(unittest.TestCase):
         self.event_info = {'name': 'test_event',
                            'description': 'testing!',
                            'author': 'admin',
-                           'event_time': EXAMPLE_TIME,
-                           'created_at': EXAMPLE_TIME}
+                           'event_time': EXAMPLE_TIME_STRING,
+                           'created_at': EXAMPLE_TIME_STRING}
         self.test_event = app.Event(**self.event_info)
         # Create mock DB for testing
         self.client = mongomock.MongoClient()
@@ -34,9 +35,9 @@ class TestEventsDB(unittest.TestCase):
         test_info = {'name': 'test_event',
                      'description': 'testing!',
                      'author': 'admin',
-                     'event_time': EXAMPLE_TIME, }
-        info = app.build_event_info(test_info, EXAMPLE_TIME)
-        self.assertEqual(info['created_at'], EXAMPLE_TIME)
+                     'event_time': EXAMPLE_TIME_STRING, }
+        info = app.build_event_info(test_info, EXAMPLE_TIME_STRING)
+        self.assertEqual(info['created_at'], EXAMPLE_TIME_STRING)
 
 
 if __name__ == '__main__':

--- a/events/test_routes.py
+++ b/events/test_routes.py
@@ -8,7 +8,8 @@ from bson import json_util
 import mongomock
 from app import app, os, connect_to_mongodb
 
-EXAMPLE_TIME = datetime.datetime(2019, 6, 11, 10, 33, 1, 100000)
+EXAMPLE_TIME = datetime.datetime(
+    2019, 6, 11, 10, 33, 1, 100000).isoformat(" ", "seconds")
 
 VALID_REQUEST_INFO = {
     'event_name': 'valid_event',

--- a/events/test_routes.py
+++ b/events/test_routes.py
@@ -8,32 +8,32 @@ from bson import json_util
 import mongomock
 from app import app, os, connect_to_mongodb
 
-EXAMPLE_TIME = datetime.datetime(
+EXAMPLE_TIME_STRING = datetime.datetime(
     2019, 6, 11, 10, 33, 1, 100000).isoformat(sep=" ", timespec="seconds")
 
 VALID_REQUEST_INFO = {
     'event_name': 'valid_event',
     'description': 'This event is formatted correctly!',
     'author_id': 'admin',
-    'event_time': EXAMPLE_TIME}
+    'event_time': EXAMPLE_TIME_STRING}
 INVALID_REQUEST_INFO_MISSING_ATTRIBUTE = {
     'event_name': 'invalid_event_missing',
     'description': 'This event is missing an author!',
-    'event_time': EXAMPLE_TIME}
+    'event_time': EXAMPLE_TIME_STRING}
 
 VALID_DB_EVENT = {
     'name': 'valid_event',
     'description': 'This event is formatted correctly!',
     'author': 'admin',
-    'event_time': EXAMPLE_TIME,
-    'created_at': EXAMPLE_TIME,
+    'event_time': EXAMPLE_TIME_STRING,
+    'created_at': EXAMPLE_TIME_STRING,
     'event_id': 'unique_event_id0'}
 VALID_DB_EVENT_WITH_ID = {
     'name': 'test_event',
     'description': 'This event is formatted correctly too!',
     'author': 'admin',
-    'event_time': EXAMPLE_TIME,
-    'created_at': EXAMPLE_TIME,
+    'event_time': EXAMPLE_TIME_STRING,
+    'created_at': EXAMPLE_TIME_STRING,
     'event_id': 'unique_event_id1'}
 
 

--- a/events/test_routes.py
+++ b/events/test_routes.py
@@ -1,7 +1,6 @@
 """Unit tests for events service HTTP routes."""
 
 import unittest
-from unittest.mock import MagicMock
 import datetime
 from contextlib import contextmanager
 from bson import json_util

--- a/events/test_routes.py
+++ b/events/test_routes.py
@@ -9,7 +9,7 @@ import mongomock
 from app import app, os, connect_to_mongodb
 
 EXAMPLE_TIME = datetime.datetime(
-    2019, 6, 11, 10, 33, 1, 100000).isoformat(" ", "seconds")
+    2019, 6, 11, 10, 33, 1, 100000).isoformat(sep=" ", timespec="seconds")
 
 VALID_REQUEST_INFO = {
     'event_name': 'valid_event',


### PR DESCRIPTION
Similar to #45, changes the format of the created_at time for events to a string. Modified comparison of times for equality, leaving the previous functionality comparing datetime objects. Also added some tests.

This PR depends on #44, all relevant changes for this one are in the last commit. 