### PR TITLE
(S) Get event by ID

### DIFF
--- a/events/app.py
+++ b/events/app.py
@@ -62,7 +62,14 @@ def edit_event(event_id):
 @app.route('/v1/<event_id>', methods=['PUT'])
 def get_one_event(event_id):
     """Retrieve one event by event_id."""
-    pass
+    try:
+        events = app.config["COLLECTION"].find({'_id': event_id})
+        events = [Event(**ev).dict for ev in events]
+        events_dict = build_events_dict(events)
+        # handle MongoDB objects (e.g. ObjectID) that aren't JSON serializable
+        return json.loads(json_util.dumps(events_dict))
+    except DBNotConnectedError as e:
+        return "Events database was undefined.", 500
 
 
 def build_event_info(info, time):

--- a/events/app.py
+++ b/events/app.py
@@ -2,7 +2,7 @@ import os
 import datetime
 import json
 import pymongo
-from bson import json_util
+from bson import json_util, ObjectId
 
 from flask import Flask, request
 from werkzeug.exceptions import BadRequestKeyError
@@ -63,7 +63,7 @@ def edit_event(event_id):
 def get_one_event(event_id):
     """Retrieve one event by event_id."""
     try:
-        events = app.config["COLLECTION"].find({'_id': event_id})
+        events = app.config["COLLECTION"].find({'_id': ObjectId(event_id)})
         events = [Event(**ev).dict for ev in events]
         events_dict = build_events_dict(events)
         # handle MongoDB objects (e.g. ObjectID) that aren't JSON serializable

--- a/events/eventclass.py
+++ b/events/eventclass.py
@@ -68,6 +68,6 @@ class Event(namedtuple("EventTuple", EVENT_ATTRIBUTES)):
         if info['event_id']:    # only create _id field if event_id is not None
             info['_id'] = info['event_id']
             del info['event_id']
-        return dict(info)
+        return info
 
     dict = property(get_dict)

--- a/events/eventclass.py
+++ b/events/eventclass.py
@@ -59,7 +59,11 @@ class Event(namedtuple("EventTuple", EVENT_ATTRIBUTES)):
         return True
 
     def get_dict(self):
-        """Returns event info in dict form."""
+        """Returns event info in dict form.
+
+        Usually used to insert event info into the dictionary, so this converts
+        the field event_id into _id to correspond with the MongoDB _id field.
+        """
         info = self._asdict()
         if info['event_id']:    # only create _id field if event_id is not None
             info['_id'] = info['event_id']

--- a/events/eventclass.py
+++ b/events/eventclass.py
@@ -60,6 +60,10 @@ class Event(namedtuple("EventTuple", EVENT_ATTRIBUTES)):
 
     def get_dict(self):
         """Returns event info in dict form."""
-        return self._asdict()
+        info = self._asdict()
+        if info['event_id']:    # only create _id field if event_id is not None
+            info['_id'] = info['event_id']
+            del info['event_id']
+        return dict(info)
 
     dict = property(get_dict)

--- a/events/test_events_class.py
+++ b/events/test_events_class.py
@@ -18,16 +18,16 @@ class TestEventsClass(unittest.TestCase):
 
     def test_construct_event(self):
         event = app.Event(**self.test_info)
-        self.test_info['event_id'] = None
-        self.assertEqual(event.dict, self.test_info)
+        result_dict = dict(event_id=None, **self.test_info)
+        self.assertEqual(event.dict, result_dict)
 
         event_with_id = app.Event(**self.test_info_with_id)
-        self.assertEqual(event_with_id.dict, self.test_info_with_id)
+        result_dict = dict(_id=1, **self.test_info)
+        self.assertEqual(event_with_id.dict, result_dict)
 
         event_with_db_id = app.Event(**self.test_info_with_db_id)
-        self.test_info_with_db_id['event_id'] = 2
-        del self.test_info_with_db_id['_id']
-        self.assertEqual(event_with_db_id.dict, self.test_info_with_db_id)
+        result_dict = dict(_id=2, **self.test_info)
+        self.assertEqual(event_with_db_id.dict, result_dict)
 
     def test_constuct_event_error(self):
         info_missing_name = self.test_info.copy()

--- a/events/test_routes.py
+++ b/events/test_routes.py
@@ -20,20 +20,21 @@ INVALID_REQUEST_INFO_MISSING_ATTRIBUTE = {
     'description': 'This event is missing an author!',
     'event_time': EXAMPLE_TIME}
 
+UNIQUE_EVENT_ID = 'unique_event_id'
 VALID_DB_EVENT = {
     'name': 'valid_event',
     'description': 'This event is formatted correctly!',
     'author': 'admin',
     'event_time': EXAMPLE_TIME,
     'created_at': EXAMPLE_TIME,
-    '_id': 'unique_event_id0'}
+    '_id': UNIQUE_EVENT_ID}
 VALID_DB_EVENT_WITH_ID = {
     'name': 'test_event',
     'description': 'This event is formatted correctly too!',
     'author': 'admin',
     'event_time': EXAMPLE_TIME,
     'created_at': EXAMPLE_TIME,
-    '_id': 'unique_event_id1'}
+    '_id': 'different_event_id'}
 
 
 @contextmanager
@@ -131,6 +132,50 @@ class TestGetEventsRoute(unittest.TestCase):
                 del os.environ["MONGODB_URI"]
             app.config["COLLECTION"] = connect_to_mongodb()
             response = self.client.get('/v1/')
+            self.assertEqual(response.status_code, 500)
+
+
+class TestGetEventByID(unittest.TestCase):
+    """Test searching for an event by name at endpoint GET /v1/."""
+
+    def setUp(self):
+        """Set up test client and seed mock DB."""
+        self.coll = mongomock.MongoClient().db.collection
+        app.config["COLLECTION"] = self.coll
+        app.config["TESTING"] = True
+        self.client = app.test_client()
+        self.fake_events = [
+            VALID_DB_EVENT,
+            VALID_DB_EVENT_WITH_ID
+        ]
+        self.coll.insert_many(self.fake_events)
+
+    def test_search_existing_event(self):
+        "Search for an event that exists in the DB."
+        response = self.client.put('/v1/' + UNIQUE_EVENT_ID)
+        self.assertEqual(response.status_code, 200)
+        data = json_util.loads(response.data)
+
+        self.assertEqual(data['events'][0]['_id'], UNIQUE_EVENT_ID)
+        self.assertEqual(len(data['events']), 1)
+        self.assertEqual(data['num_events'], 1)
+
+    def test_search_nonexisting_event(self):
+        "Search for an event that doesn't exist in the DB."
+        response = self.client.put('/v1/' + "nonexistent_event_id")
+        self.assertEqual(response.status_code, 200)
+        data = json_util.loads(response.data)
+
+        self.assertEqual(len(data['events']), 0)
+        self.assertEqual(data['num_events'], 0)
+
+    def test_db_not_defined(self):
+        """Test getting events when DB connection is undefined."""
+        with environ(os.environ):
+            if "MONGODB_URI" in os.environ:
+                del os.environ["MONGODB_URI"]
+            app.config["COLLECTION"] = connect_to_mongodb()
+            response = self.client.put('/v1/' + UNIQUE_EVENT_ID)
             self.assertEqual(response.status_code, 500)
 
 

--- a/events/test_routes.py
+++ b/events/test_routes.py
@@ -26,14 +26,14 @@ VALID_DB_EVENT = {
     'author': 'admin',
     'event_time': EXAMPLE_TIME,
     'created_at': EXAMPLE_TIME,
-    'event_id': 'unique_event_id0'}
+    '_id': 'unique_event_id0'}
 VALID_DB_EVENT_WITH_ID = {
     'name': 'test_event',
     'description': 'This event is formatted correctly too!',
     'author': 'admin',
     'event_time': EXAMPLE_TIME,
     'created_at': EXAMPLE_TIME,
-    'event_id': 'unique_event_id1'}
+    '_id': 'unique_event_id1'}
 
 
 @contextmanager

--- a/events/test_routes.py
+++ b/events/test_routes.py
@@ -20,21 +20,18 @@ INVALID_REQUEST_INFO_MISSING_ATTRIBUTE = {
     'description': 'This event is missing an author!',
     'event_time': EXAMPLE_TIME}
 
-UNIQUE_EVENT_ID = 'unique_event_id'
 VALID_DB_EVENT = {
     'name': 'valid_event',
     'description': 'This event is formatted correctly!',
     'author': 'admin',
     'event_time': EXAMPLE_TIME,
-    'created_at': EXAMPLE_TIME,
-    '_id': UNIQUE_EVENT_ID}
+    'created_at': EXAMPLE_TIME}
 VALID_DB_EVENT_WITH_ID = {
     'name': 'test_event',
     'description': 'This event is formatted correctly too!',
     'author': 'admin',
     'event_time': EXAMPLE_TIME,
-    'created_at': EXAMPLE_TIME,
-    '_id': 'different_event_id'}
+    'created_at': EXAMPLE_TIME}
 
 
 @contextmanager
@@ -152,17 +149,19 @@ class TestGetEventByID(unittest.TestCase):
 
     def test_search_existing_event(self):
         "Search for an event that exists in the DB."
-        response = self.client.put('/v1/' + UNIQUE_EVENT_ID)
+        id_to_search = VALID_DB_EVENT['_id']
+        response = self.client.put(f'/v1/{id_to_search}')
         self.assertEqual(response.status_code, 200)
         data = json_util.loads(response.data)
 
-        self.assertEqual(data['events'][0]['_id'], UNIQUE_EVENT_ID)
+        self.assertEqual(data['events'][0]['_id'], id_to_search)
         self.assertEqual(len(data['events']), 1)
         self.assertEqual(data['num_events'], 1)
 
     def test_search_nonexisting_event(self):
         "Search for an event that doesn't exist in the DB."
-        response = self.client.put('/v1/' + "nonexistent_event_id")
+        nonexistent_event_id = "123456789123456789123456"
+        response = self.client.put('/v1/' + nonexistent_event_id)
         self.assertEqual(response.status_code, 200)
         data = json_util.loads(response.data)
 
@@ -171,11 +170,12 @@ class TestGetEventByID(unittest.TestCase):
 
     def test_db_not_defined(self):
         """Test getting events when DB connection is undefined."""
+        id_to_search = VALID_DB_EVENT['_id']
         with environ(os.environ):
             if "MONGODB_URI" in os.environ:
                 del os.environ["MONGODB_URI"]
             app.config["COLLECTION"] = connect_to_mongodb()
-            response = self.client.put('/v1/' + UNIQUE_EVENT_ID)
+            response = self.client.put(f'/v1/{id_to_search}')
             self.assertEqual(response.status_code, 500)
 
 


### PR DESCRIPTION
Added ability to retrieve one event by its unique event ID. 

Slightly restructured the way events are converted into dict form so an `event_id` field doesn't get stored in MongoDB, which could have led to duplicate or conflicting info. The `get_dict` function now just moves the info in `event_id` to a field called `_id`.

Namedtuple doesn't allow `_id` as a field so I couldn't just modify the required attributes. 