### PR TITLE
(S) Fix pageserve login bug

### DIFF
--- a/pageserve/templates/base.html
+++ b/pageserve/templates/base.html
@@ -36,19 +36,30 @@ limitations under the License.
         {% block header %}{% endblock header %}
     </header>
     {% block login_buttons %}
-    {% if not session['user'] %}
+    {% if not session['gauth_token'] %}
     <div id="sign_in_button">
         <div class="g-signin2" data-onsuccess="onSignIn" data-theme="dark"></div>
         <script>
+            console.log("script loaded");
+
             function onSignIn(googleUser) {
+                console.log("onSignIn");
                 // Secure Google ID token to send to backend for verification.
                 var id_token = googleUser.getAuthResponse().id_token;
                 var xhr = new XMLHttpRequest();
                 xhr.open('POST', "authenticate");
                 xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+                console.log("Found token");
                 xhr.onload = function () {
-                    // show the "Sign out" button
-                    window.location.reload()
+                    if (xhr.status === 200) {
+                        // backend authentication successful
+                        console.log("Sign in successful, reloading");
+                        // show the "Sign out" button
+                        window.location.reload();
+                    } else {
+                        // unsuccessful, sign out Google auth
+                        signOut();
+                    }
                 };
                 xhr.send('gauth_token=' + id_token);
             }
@@ -57,17 +68,17 @@ limitations under the License.
     {% else %}
     <div id="sign_out_button">
         <a href="#" onclick="signOut();">Sign out</a>
-        <script>
-            function signOut() {
-                var auth2 = gapi.auth2.getAuthInstance();
-                auth2.signOut().then(function () {
-                    window.location.replace("/v1/sign_out");
-                });
-            }
-        </script>
-        <h4>Hi {{ session['user']['name'] }}!</h4>
+        <h4>Hi {{ session['name'] }}!</h4>
     </div>
     {% endif %}
+    <script>
+        function signOut() {
+            var auth2 = gapi.auth2.getAuthInstance();
+            auth2.signOut().then(function () {
+                window.location.replace("/v1/sign_out");
+            });
+        }
+    </script>
     {% endblock login_buttons %}
     {% block content %}{% endblock content %}
 </body>

--- a/pageserve/templates/base.html
+++ b/pageserve/templates/base.html
@@ -51,7 +51,7 @@ limitations under the License.
                 xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
                 console.log("Found token");
                 xhr.onload = function () {
-                    if (xhr.status === 200) {
+                    if (xhr.status === 201) {
                         // backend authentication successful
                         console.log("Sign in successful, reloading");
                         // show the "Sign out" button

--- a/pageserve/templates/base.html
+++ b/pageserve/templates/base.html
@@ -40,21 +40,16 @@ limitations under the License.
     <div id="sign_in_button">
         <div class="g-signin2" data-onsuccess="onSignIn" data-theme="dark"></div>
         <script>
-            console.log("script loaded");
-
             function onSignIn(googleUser) {
-                console.log("onSignIn");
                 // Secure Google ID token to send to backend for verification.
                 var id_token = googleUser.getAuthResponse().id_token;
                 var xhr = new XMLHttpRequest();
                 xhr.open('POST', "authenticate");
                 xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
-                console.log("Found token");
                 xhr.onload = function () {
                     if (xhr.status === 201) {
                         // backend authentication successful
-                        console.log("Sign in successful, reloading");
-                        // show the "Sign out" button
+                        // reload to show the "Sign out" button
                         window.location.reload();
                     } else {
                         // unsuccessful, sign out Google auth


### PR DESCRIPTION
Fix https://github.com/knative-portability/large-events/issues/54. The problem was that I unfolded the session data from a nested object to 3 top level strings in an older PR but forgot to change the check for that in base.html. This caused a reload loop where Google sign in button would authenticate but base.html didn't find the cookie it was looking for so it reloaded and tried to authenticate again. I also added in some safegaurding for if the users service goes down or responds badly. Previously, I think this would also cause a reload loop on attempted sign in, but now it just signs out the Google sign in button.