### PR TITLE
(XS) Fix ID usage from get_user()

### DIFF
--- a/pageserve/app.py
+++ b/pageserve/app.py
@@ -128,7 +128,7 @@ def add_post():
             400 if post info is malformatted
     """
     url = app.config['POSTS_ENDPOINT'] + 'add'
-    form_data = dict(**request.form.to_dict(), author_id=get_user())
+    form_data = dict(**request.form.to_dict(), author_id=get_user()["user_id"])
     r = requests.post(url, data=form_data, files=request.files)
     return r.content, r.status_code
 
@@ -151,7 +151,7 @@ def add_event():
             400 if event info is malformatted
     """
     url = app.config['EVENTS_ENDPOINT'] + 'add'
-    form_data = dict(**request.form.to_dict(), author_id=get_user())
+    form_data = dict(**request.form.to_dict(), author_id=get_user()["user_id"])
     r = requests.post(url, data=form_data)
     return r.content, r.status_code
 

--- a/pageserve/templates/index.html
+++ b/pageserve/templates/index.html
@@ -33,9 +33,9 @@ limitations under the License.
 <p>{{post.text}}</p>
 {% endif %}
 {% if post.files %}
-  {% for file in post.files %}
-  <img src="{{ file }}">
-  {% endfor %}
+{% for file in post.files %}
+<img src="{{ file }}">
+{% endfor %}
 {% endif %}
 
 <hr>
@@ -49,13 +49,13 @@ limitations under the License.
         <select id="event_id" name="event_id">
             {% for event in events %}
             <!-- TODO (cmei4444) - update field names once other changes are pushed -->
-            <option value="{{ event.event_id['$oid'] }}">{{ event.event_id['$oid'] }} - {{ event.name }}</option>
+            <option value="{{ event._id['$oid'] }}">{{ event._id['$oid'] }} - {{ event.name }}</option>
             {% endfor %}
         </select>
     </div>
     <div>
         <label for="text">Text:</label>
-        <textarea type="text" rows = "5" cols = "60" id="text" name="text">
+        <textarea type="text" rows="5" cols="60" id="text" name="text">
           Enter your post here.
         </textarea>
     </div>

--- a/pageserve/test_routes.py
+++ b/pageserve/test_routes.py
@@ -31,7 +31,6 @@ ERROR_BAD_TOKEN_TEXT = "Error: bad gauth_token."
 ERROR_BAD_TOKEN_STATUS = 400
 VALID_USER_AUTH_STATUS = 201
 
-EXAMPLE_USER = "app_user"
 EXAMPLE_USER_OBJECT = {
     "user_id": "app_user",
     "name": "app_user"}

--- a/pageserve/test_routes.py
+++ b/pageserve/test_routes.py
@@ -32,6 +32,9 @@ ERROR_BAD_TOKEN_STATUS = 400
 VALID_USER_AUTH_STATUS = 201
 
 EXAMPLE_USER = "app_user"
+EXAMPLE_USER_OBJECT = {
+    "user_id": "app_user",
+    "name": "app_user"}
 
 VALID_POST_FORM = {
     'event_id': 'valid_post_id',
@@ -171,7 +174,7 @@ class TestTemplateRoutes(TestCase):
         """Set up test client."""
         self.client = app.app.test_client()
 
-    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER))
+    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
     @patch('app.has_edit_access', MagicMock(return_value=True))
     @patch('app.get_posts', MagicMock(return_value=EXAMPLE_POSTS))
     def test_index(self):
@@ -184,7 +187,7 @@ class TestTemplateRoutes(TestCase):
         self.assertContext('posts', EXAMPLE_POSTS)
         self.assertContext('app_config', app.app.config)
 
-    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER))
+    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
     @patch('app.has_edit_access', MagicMock(return_value=True))
     @patch('app.get_posts', MagicMock(side_effect=RuntimeError))
     def test_index_posts_fail(self):
@@ -192,7 +195,7 @@ class TestTemplateRoutes(TestCase):
         response = self.client.get('/v1/')
         self.assertEqual(response.status_code, 500)
 
-    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER))
+    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
     @patch('app.has_edit_access', MagicMock(return_value=True))
     @patch('app.get_events', MagicMock(return_value=EXAMPLE_EVENTS))
     def test_show_events(self):
@@ -205,7 +208,7 @@ class TestTemplateRoutes(TestCase):
         self.assertContext('events', EXAMPLE_EVENTS)
         self.assertContext('app_config', app.app.config)
 
-    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER))
+    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
     @patch('app.has_edit_access', MagicMock(return_value=True))
     @patch('app.get_events', MagicMock(side_effect=RuntimeError))
     def test_index_events_fail(self):
@@ -222,7 +225,7 @@ class TestAddPostRoute(unittest.TestCase):
         self.client = app.app.test_client()
         self.expected_url = app.app.config['POSTS_ENDPOINT'] + 'add'
 
-    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER))
+    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
     @requests_mock.Mocker()
     def test_add_valid_post(self, mock_requests):
         """Tests adding a valid post."""
@@ -235,7 +238,7 @@ class TestAddPostRoute(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data.decode(), "Example success message")
 
-    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER))
+    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
     @requests_mock.Mocker()
     def test_add_invalid_post(self, mock_requests):
         """Tests adding an invalid post."""
@@ -257,7 +260,7 @@ class TestAddEventRoute(unittest.TestCase):
         self.client = app.app.test_client()
         self.expected_url = app.app.config['EVENTS_ENDPOINT'] + 'add'
 
-    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER))
+    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
     @requests_mock.Mocker()
     def test_add_valid_event(self, mock_requests):
         """Tests adding a valid event."""
@@ -270,7 +273,7 @@ class TestAddEventRoute(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data.decode(), "Example success message")
 
-    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER))
+    @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
     @requests_mock.Mocker()
     def test_add_invalid_event(self, mock_requests):
         """Tests adding an invalid event."""


### PR DESCRIPTION
Parts of pageserve and related tests used to call an old faked version of `get_user()` that returned a string user ID. Now, `get_user()` returns an object with `user_id`, `name`, and `is_organizer` fields, so I updated pageserve accordingly to accommodate for this.