### PR TITLE
(S) Make add post/event redirect to homepage

### DIFF
--- a/pageserve/app.py
+++ b/pageserve/app.py
@@ -136,13 +136,15 @@ def add_post():
         All files to be uploaded(can be multiple)
 
     Response:
-        String response and response code returned by posts service:
-            201 if post added successfully
-            400 if post info is malformatted
+        Redirect to index if 201 response from posts service.
+        Error message and status 400 otherwise.
     """
     url = app.config['POSTS_ENDPOINT'] + 'add'
     form_data = dict(**request.form.to_dict(), author_id=get_user()["user_id"])
     r = requests.post(url, data=form_data, files=request.files)
+    if r.status_code == 201:
+        # upload successful, redirect to index
+        return redirect(url_for("index"))
     return r.content, r.status_code
 
 
@@ -159,13 +161,15 @@ def add_event():
         event_time: time of event
 
     Response:
-        String response and response code returned by posts service:
-            201 if event added successfully
-            400 if event info is malformatted
+        Redirect to index if 201 response from events service.
+        Error message and status 400 otherwise.
     """
     url = app.config['EVENTS_ENDPOINT'] + 'add'
     form_data = dict(**request.form.to_dict(), author_id=get_user()["user_id"])
     r = requests.post(url, data=form_data)
+    if r.status_code == 201:
+        # upload successful, redirect to index
+        return redirect(url_for("index"))
     return r.content, r.status_code
 
 

--- a/pageserve/test_routes.py
+++ b/pageserve/test_routes.py
@@ -21,6 +21,7 @@ import ast
 import requests_mock
 from flask_testing import TestCase
 import flask
+from flask import url_for
 import app
 
 VALID_SESSION = {
@@ -144,9 +145,11 @@ class TestSignOut(unittest.TestCase):
             # empty session after
             self.assertNotIn("user_id", flask.session)
             self.assertEqual(len(flask.session), 0)
-            # correct redirect response
-            self.assertEqual(result.status_code, 302)  # redirect
-            self.assertIn("redirect", result.data.decode())
+            # check for redirect to index
+            self.assertEqual(result.status_code, 302)
+            with app.app.test_request_context():
+                self.assertTrue(
+                    result.headers['location'].endswith(url_for('index')))
 
     def test_was_not_logged_in(self):
         """Try to sign out a user that was not logged in."""
@@ -159,9 +162,11 @@ class TestSignOut(unittest.TestCase):
             # empty session after
             self.assertNotIn("user_id", flask.session)
             self.assertEqual(len(flask.session), 0)
-            # correct redirect response
-            self.assertEqual(result.status_code, 302)  # redirect
-            self.assertIn("redirect", result.data.decode())
+            # check for redirect to index
+            self.assertEqual(result.status_code, 302)
+            with app.app.test_request_context():
+                self.assertTrue(
+                    result.headers['location'].endswith(url_for('index')))
 
 
 class TestTemplateRoutes(TestCase):
@@ -240,7 +245,11 @@ class TestAddPostRoute(unittest.TestCase):
 
         response = self.client.post('/v1/add_post', data=VALID_POST_FORM)
 
-        self.assertEqual(response.status_code, 302)  # redirect to index
+        # check for redirect to index
+        self.assertEqual(response.status_code, 302)
+        with app.app.test_request_context():
+            self.assertTrue(
+                response.headers['location'].endswith(url_for('index')))
 
     @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
     @requests_mock.Mocker()
@@ -274,7 +283,11 @@ class TestAddEventRoute(unittest.TestCase):
 
         response = self.client.post('/v1/add_event', data=VALID_EVENT_FORM)
 
-        self.assertEqual(response.status_code, 302)  # redirect to index
+        # check for redirect to index
+        self.assertEqual(response.status_code, 302)
+        with app.app.test_request_context():
+            self.assertTrue(
+                response.headers['location'].endswith(url_for('index')))
 
     @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
     @requests_mock.Mocker()

--- a/pageserve/test_routes.py
+++ b/pageserve/test_routes.py
@@ -240,8 +240,7 @@ class TestAddPostRoute(unittest.TestCase):
 
         response = self.client.post('/v1/add_post', data=VALID_POST_FORM)
 
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data.decode(), "Example success message")
+        self.assertEqual(response.status_code, 302)  # redirect to index
 
     @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
     @requests_mock.Mocker()
@@ -275,8 +274,7 @@ class TestAddEventRoute(unittest.TestCase):
 
         response = self.client.post('/v1/add_event', data=VALID_EVENT_FORM)
 
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data.decode(), "Example success message")
+        self.assertEqual(response.status_code, 302)  # redirect to index
 
     @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
     @requests_mock.Mocker()


### PR DESCRIPTION
Currently, when you add a post or event using the forms on pageserve, you are sent to a page displaying the response from the posts/events service which is just a white page with the Mongo ID of the inserted data. This change still shows the response on failure, but if the post/event was successfully uploaded (status 201), it redirects you back to the index page.