### PR TITLE
(S) Change edit access to is organizer

### DIFF
--- a/events/app.py
+++ b/events/app.py
@@ -67,8 +67,6 @@ def add_event():
             'author': request.form['author_id'],
             'event_time': request.form['event_time']
         }
-        # TODO(cmei4444): Athenticate user and verify that user has event
-        # editing access
         current_time = datetime.datetime.utcnow().isoformat(sep=' ',
                                                             timespec='seconds')
         info = build_event_info(info, current_time)

--- a/pageserve/app.py
+++ b/pageserve/app.py
@@ -33,7 +33,7 @@ def index():
         return render_template(
             'index.html',
             posts=get_posts(),
-            auth=has_edit_access(get_user()),
+            auth=is_organizer(get_user()),
             events=get_events(),
             app_config=app.config
         )
@@ -60,7 +60,7 @@ def show_events():
         return render_template(
             'events.html',
             events=get_events(),
-            auth=has_edit_access(get_user()),
+            auth=is_organizer(get_user()),
             app_config=app.config
         )
     except RuntimeError as error:
@@ -223,13 +223,13 @@ def parse_events(events_dict):
     return events_dict['events']
 
 
-def has_edit_access(user):
-    """Determines if the user with the given info has edit access."""
+def is_organizer(user):
+    """Determines if the user with the given info is an event organizer."""
     if user is None:
         return False
     url = app.config['USERS_ENDPOINT'] + 'authorization'
     response = requests.post(url, data={'user_id': user['user_id']})
-    return response.json()['edit_access'] is True
+    return response.json()['is_organizer'] is True
 
 
 def get_user():

--- a/pageserve/app.py
+++ b/pageserve/app.py
@@ -55,7 +55,7 @@ def search_event():
         if response.status_code == 200:
             return render_template(
                 'search_results.html',
-                auth=has_edit_access(get_user()),
+                auth=is_organizer(get_user()),
                 events=parse_events(response.json()),
                 app_config=app.config
             )

--- a/pageserve/templates/base.html
+++ b/pageserve/templates/base.html
@@ -88,9 +88,9 @@ limitations under the License.
     </header>
     {% block auth_notice %}
       {% if auth %}
-        <p>You have edit authorization!</p>
+        <p>You are an event organizer!</p>
       {% else %}
-        <p>You do not have edit authorization.</p>
+        <p>You are not an event organizer.</p>
       {% endif %}
     {% endblock auth_notice %}
     {% block content %}{% endblock content %}

--- a/pageserve/test_routes.py
+++ b/pageserve/test_routes.py
@@ -185,7 +185,7 @@ class TestTemplateRoutes(TestCase):
         self.client = app.app.test_client()
 
     @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
-    @patch('app.has_edit_access', MagicMock(return_value=True))
+    @patch('app.is_organizer', MagicMock(return_value=True))
     @patch('app.get_posts', MagicMock(return_value=EXAMPLE_POSTS))
     def test_index(self):
         """Checks index page is rendered correctly by GET /v1/."""
@@ -198,7 +198,7 @@ class TestTemplateRoutes(TestCase):
         self.assertContext('app_config', app.app.config)
 
     @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
-    @patch('app.has_edit_access', MagicMock(return_value=True))
+    @patch('app.is_organizer', MagicMock(return_value=True))
     @patch('app.get_posts', MagicMock(side_effect=RuntimeError))
     def test_index_posts_fail(self):
         """Checks GET /v1/ response when posts cannot be retrieved."""
@@ -206,7 +206,7 @@ class TestTemplateRoutes(TestCase):
         self.assertEqual(response.status_code, 500)
 
     @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
-    @patch('app.has_edit_access', MagicMock(return_value=True))
+    @patch('app.is_organizer', MagicMock(return_value=True))
     @patch('app.get_events', MagicMock(return_value=EXAMPLE_EVENTS))
     def test_show_events(self):
         """Checks sub-events page is rendered correctly by GET /v1/events."""
@@ -219,7 +219,7 @@ class TestTemplateRoutes(TestCase):
         self.assertContext('app_config', app.app.config)
 
     @patch('app.get_user', MagicMock(return_value=EXAMPLE_USER_OBJECT))
-    @patch('app.has_edit_access', MagicMock(return_value=True))
+    @patch('app.is_organizer', MagicMock(return_value=True))
     @patch('app.get_events', MagicMock(side_effect=RuntimeError))
     def test_index_events_fail(self):
         """Checks GET /v1/events response when events cannot be retrieved."""

--- a/pageserve/test_routes.py
+++ b/pageserve/test_routes.py
@@ -256,7 +256,7 @@ class TestSearchEventsRoute(TestCase):
         self.client = app.app.test_client()
         self.expected_url = app.app.config['EVENTS_ENDPOINT'] + 'search'
 
-    @patch('app.has_edit_access', MagicMock(return_value=True))
+    @patch('app.is_organizer', MagicMock(return_value=True))
     @requests_mock.Mocker()
     def test_search_existing_events(self, mock_requests):
         """Test searching for existing events"""
@@ -273,7 +273,7 @@ class TestSearchEventsRoute(TestCase):
         self.assertContext('events', EXAMPLE_EVENTS)
         self.assertContext('app_config', app.app.config)
 
-    @patch('app.has_edit_access', MagicMock(return_value=True))
+    @patch('app.is_organizer', MagicMock(return_value=True))
     @requests_mock.Mocker()
     def test_search_no_events_found(self, mock_requests):
         """Test searching for nonexisting events"""

--- a/pageserve/test_serve.py
+++ b/pageserve/test_serve.py
@@ -22,8 +22,8 @@ import requests_mock
 import flask
 import app
 
-AUTHORIZED_RESPONSE_JSON = {'edit_access': True}
-UNAUTHORIZED_RESPONSE_JSON = {'edit_access': False}
+AUTHORIZED_RESPONSE_JSON = {'is_organizer': True}
+UNAUTHORIZED_RESPONSE_JSON = {'is_organizer': False}
 
 VALID_SESSION = {
     'user_id': 'abc123 pretend I am a user ID.',
@@ -73,25 +73,25 @@ class TestServe(unittest.TestCase):
             self.assertIsNone(app.get_user())
 
     @requests_mock.Mocker()
-    def test_edit_access(self, requests_mocker):
+    def test_is_organizer(self, requests_mocker):
         """Tests if authorization is correctly retrieved from users service.
 
         This test mocks away requests to the users service which is normally
-        called by app.has_edit_access.
+        called by app.is_organizer.
         """
         # is authorized
         requests_mocker.post(app.app.config['USERS_ENDPOINT'] + 'authorization',
                              json=AUTHORIZED_RESPONSE_JSON)
-        self.assertTrue(app.has_edit_access(
+        self.assertTrue(app.is_organizer(
             {'user_id': 'Pretend I am authorized.'}))
         # not authorized
         requests_mocker.post(app.app.config['USERS_ENDPOINT'] + 'authorization',
                              json=UNAUTHORIZED_RESPONSE_JSON)
-        self.assertFalse(app.has_edit_access(
+        self.assertFalse(app.is_organizer(
             {'user_id': 'Pretend I am NOT authorized.'}))
         # No user sent give no authorization. This might happens when a user
         # is logged out so app.get_user() returns None.
-        self.assertFalse(app.has_edit_access(None))
+        self.assertFalse(app.is_organizer(None))
 
     @mock.patch('app.os')
     def test_config_endpoints(self, mock_os):

--- a/users/app.py
+++ b/users/app.py
@@ -65,12 +65,12 @@ def authenticate_and_get_user():
 
 @app.route('/v1/authorization', methods=['POST'])
 def get_authorization():
-    """Finds whether the given user is authorized for edit access."""
+    """Finds whether the given user is an authorized organizer."""
     user_id = request.form.get('user_id')
     if user_id is None:
         return 'Error: You must supply a "user_id" POST parameter!', 400
     authorized = find_authorization_in_db(user_id, app.config['COLLECTION'])
-    return jsonify(edit_access=authorized)
+    return jsonify(is_organizer=authorized)
 
 
 @app.route('/v1/authorization/update', methods=['POST'])
@@ -87,7 +87,7 @@ def update_authorization():
             return 'Not authorized to make this request.', 403
         update_user_authorization_in_db(
             target_user_id, is_organizer, app.config['COLLECTION'])
-        return jsonify(edit_access=is_organizer)
+        return jsonify(is_organizer=is_organizer)
     except (AttributeError, ValueError, KeyError, BadRequestKeyError) as error:
         return f'Error: {error}', 400
 

--- a/users/test_routes.py
+++ b/users/test_routes.py
@@ -155,7 +155,7 @@ class TestGetAuthorization(unittest.TestCase):
             '/v1/authorization', data={'user_id': AUTHORIZED_USER_ID})
         self.assertEqual(result.status_code, 200)
         response_body = json.loads(result.data)
-        self.assertEqual(response_body, {'edit_access': True})
+        self.assertEqual(response_body, {'is_organizer': True})
 
     def test_not_authorized(self):
         """Get authorization of non-authorized user."""
@@ -163,7 +163,7 @@ class TestGetAuthorization(unittest.TestCase):
             '/v1/authorization', data={'user_id': NON_AUTHORIZED_USER_ID})
         self.assertEqual(result.status_code, 200)
         response_body = json.loads(result.data)
-        self.assertEqual(response_body, {'edit_access': False})
+        self.assertEqual(response_body, {'is_organizer': False})
 
     def test_malformatted_in_db(self):
         """Get authorization of user that is malformatted in the db."""
@@ -171,7 +171,7 @@ class TestGetAuthorization(unittest.TestCase):
             '/v1/authorization', data={'user_id': MALFORMATTED_IN_DB_USER})
         self.assertEqual(result.status_code, 200)
         response_body = json.loads(result.data)
-        self.assertEqual(response_body, {'edit_access': False})
+        self.assertEqual(response_body, {'is_organizer': False})
 
     def test_missing_param(self):
         """Try to get authorization but don't supply user_id."""


### PR DESCRIPTION
Standardize use of `'is_organizer'` rather than mix of that and `'edit_access'` for authorization status.