### PR TITLE
(XS) Fix/improve delete buttons

### DIFF
--- a/pageserve/static/style.css
+++ b/pageserve/static/style.css
@@ -90,6 +90,23 @@
   box-shadow: 0 0 8px #cccccc;
 }
 
+.content_box .delete_button {
+  border: 1px solid #8c1515;
+  color: #8c1515;
+  background-color: white;
+  padding: 12px 24px;
+  border-radius: 4px;
+  display: block;
+  transition: all 200ms;
+  width: fit-content;
+  margin: 12px auto;
+}
+
+.content_box .delete_button:hover {
+  color: white;
+  background-color: #8c1515;
+}
+
 hr.form_divider {
   border-top: 5px double #8c8b8b;
 }

--- a/pageserve/templates/index.html
+++ b/pageserve/templates/index.html
@@ -61,7 +61,7 @@ limitations under the License.
         {% endif %}
 
         {% if post.author_id == session["user_id"] %}
-            <a href="#" onClick="deletePost('{{ post._id['$oid'] }}');">Delete</a>
+            <a href onClick="deletePost('{{ post._id['$oid'] }}');">Delete</a>
         {% endif %}
       </div>
     {% endfor %}

--- a/pageserve/templates/index.html
+++ b/pageserve/templates/index.html
@@ -61,7 +61,7 @@ limitations under the License.
         {% endif %}
 
         {% if post.author_id == session["user_id"] %}
-            <a href onClick="deletePost('{{ post._id['$oid'] }}');">Delete</a>
+            <a href onClick="deletePost('{{ post._id['$oid'] }}');" class="delete_button">Delete Post</a>
         {% endif %}
       </div>
     {% endfor %}


### PR DESCRIPTION
Previous post delete buttons were `<a href="#" onClick=deletePost(...)>...` which worked but jumped you to the top of the page before reloading with the change (because it changed your browser location to /v1/#. Now they are just `<a href onClick=deletePost(...)>` which still work and look like buttons but keep your same scroll position on click.

Also made the delete buttons cooler while I was at it: https://screenshot.googleplex.com/S9FNmDFKtDO