### PR TITLE
(M) Posts filter by event backend

### DIFF
--- a/pageserve/app.py
+++ b/pageserve/app.py
@@ -96,7 +96,7 @@ def get_posts_for_event(event_id):
     if response.status_code == 200:
         return render_template(
             'index.html',
-            posts=parse_events(response.json()),
+            posts=parse_posts(response.json()),
             auth=is_organizer(get_user()),
             events=get_events(),
             app_config=app.config

--- a/pageserve/app.py
+++ b/pageserve/app.py
@@ -65,6 +65,23 @@ def search_event():
         return f'Error: {error}.', 400
 
 
+@app.route('/v1/get_posts/<event_id>', methods=['GET'])
+def get_posts_for_event(event_id):
+    """Retrieves all posts for a certain event and displays in web template."""
+    response = requests.get(app.config['POSTS_ENDPOINT'] +
+                            f'by_event/{event_id}')
+    if response.status_code == 200:
+        return render_template(
+            'index.html',
+            posts=get_posts(),
+            auth=has_edit_access(get_user()),
+            events=get_events(),
+            app_config=app.config
+        )
+    else:
+        return 'Unable to retrieve events', 500
+
+
 @app.route('/v1/delete_post/<post_id>', methods=['DELETE'])
 def delete_post(post_id):
     """Authenticates and proxies a request to users service to delete a post."""

--- a/pageserve/app.py
+++ b/pageserve/app.py
@@ -97,7 +97,7 @@ def get_posts_for_event(event_id):
         return render_template(
             'index.html',
             posts=parse_events(response.json()),
-            auth=has_edit_access(get_user()),
+            auth=is_organizer(get_user()),
             events=get_events(),
             app_config=app.config
         )

--- a/pageserve/app.py
+++ b/pageserve/app.py
@@ -73,7 +73,7 @@ def get_posts_for_event(event_id):
     if response.status_code == 200:
         return render_template(
             'index.html',
-            posts=get_posts(),
+            posts=parse_events(response.json()),
             auth=has_edit_access(get_user()),
             events=get_events(),
             app_config=app.config

--- a/pageserve/test_routes.py
+++ b/pageserve/test_routes.py
@@ -406,8 +406,8 @@ class TestGetPostsForEventRoute(TestCase):
     def test_get_existing_posts(self, mock_requests):
         """Checks existing posts are returned correctly."""
         mock_requests.get(self.expected_url + EXAMPLE_EVENT_ID,
-                          json={'events': EXAMPLE_POSTS,
-                                'num_events': len(EXAMPLE_POSTS)},
+                          json={'posts': EXAMPLE_POSTS,
+                                'num_posts': len(EXAMPLE_POSTS)},
                           status_code=200)
         response = self.client.get(f'/v1/get_posts/{EXAMPLE_EVENT_ID}')
         self.assertEqual(response.status_code, 200)
@@ -420,7 +420,7 @@ class TestGetPostsForEventRoute(TestCase):
     def test_get_nonexistent_posts(self, mock_requests):
         """Checks the case when no posts are found."""
         mock_requests.get(self.expected_url + DIFFERENT_EVENT_ID,
-                          json={'events': [], 'num_events': 0},
+                          json={'posts': [], 'num_posts': 0},
                           status_code=200)
         response = self.client.get(f'/v1/get_posts/{DIFFERENT_EVENT_ID}')
         self.assertEqual(response.status_code, 200)

--- a/pageserve/test_routes.py
+++ b/pageserve/test_routes.py
@@ -386,6 +386,7 @@ class TestQueryEventsByIDRoute(TestCase):
 
 @patch('app.is_organizer', MagicMock(return_value=True))
 @patch('app.get_events', MagicMock(return_value=EXAMPLE_EVENTS))
+@requests_mock.Mocker()
 class TestGetPostsForEventRoute(TestCase):
     """Tests retrieving posts for an event at GET /v1/get_posts/<event_id>."""
 
@@ -402,7 +403,6 @@ class TestGetPostsForEventRoute(TestCase):
         self.client = app.app.test_client()
         self.expected_url = app.app.config['POSTS_ENDPOINT'] + 'by_event/'
 
-    @requests_mock.Mocker()
     def test_get_existing_posts(self, mock_requests):
         """Checks existing posts are returned correctly."""
         mock_requests.get(self.expected_url + EXAMPLE_EVENT_ID,
@@ -417,7 +417,6 @@ class TestGetPostsForEventRoute(TestCase):
         self.assertContext('posts', EXAMPLE_POSTS)
         self.assertContext('app_config', app.app.config)
 
-    @requests_mock.Mocker()
     def test_get_nonexistent_posts(self, mock_requests):
         """Checks the case when no posts are found."""
         mock_requests.get(self.expected_url + DIFFERENT_EVENT_ID,
@@ -431,7 +430,6 @@ class TestGetPostsForEventRoute(TestCase):
         self.assertContext('posts', [])
         self.assertContext('app_config', app.app.config)
 
-    @requests_mock.Mocker()
     def test_posts_service_error(self, mock_requests):
         """Checks the case when posts service throws an error."""
         mock_requests.get(self.expected_url + EXAMPLE_EVENT_ID,


### PR DESCRIPTION
Created an endpoint in pageserve to connect to the posts service endpoint `GET /v1/by_event/<event_id>`, which finds all posts linked to the given event.

Only created the back-end logic, working on the front-end. 

Are there any other endpoints in other services that aren't connected to pageserve at this point?